### PR TITLE
fix for deleting text on keycode del

### DIFF
--- a/editcodeview/src/main/java/com/bigbangbutton/editcodeview/EditCodeInputConnection.java
+++ b/editcodeview/src/main/java/com/bigbangbutton/editcodeview/EditCodeInputConnection.java
@@ -25,11 +25,14 @@ class EditCodeInputConnection extends BaseInputConnection {
 
     @Override
     public boolean sendKeyEvent(KeyEvent event) {
-        if (event.getAction() == KeyEvent.ACTION_DOWN
-                && event.getKeyCode() >= KeyEvent.KEYCODE_0
-                && event.getKeyCode() <= KeyEvent.KEYCODE_9) {
-            char c = event.getKeyCharacterMap().getNumber(event.getKeyCode());
-            commitText(String.valueOf(c), 1);
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            if (event.getKeyCode() >= KeyEvent.KEYCODE_0
+                    && event.getKeyCode() <= KeyEvent.KEYCODE_9) {
+                char c = event.getKeyCharacterMap().getNumber(event.getKeyCode());
+                commitText(String.valueOf(c), 1);
+            } else if (event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
+                deleteSurroundingText(1, 0);
+            }
         }
         return super.sendKeyEvent(event);
     }


### PR DESCRIPTION
KeyEvent.KEYCODE_DEL does not delete the code/text on API 26+

Fix for https://github.com/Onum/EditCodeView/issues/1 